### PR TITLE
Periodic Expenses

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'turbolinks'
 gem 'cancancan', '~> 1.10'
 gem 'devise'
 gem 'slim-rails'
+gem 'validates_timeliness', '~> 3.0'
 gem 'whenever'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'turbolinks'
 gem 'cancancan', '~> 1.10'
 gem 'devise'
 gem 'slim-rails'
+gem 'whenever'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -51,4 +52,6 @@ group :test do
 
   gem 'capybara'
   gem 'capybara-webkit'
+
+  gem 'timecop', '~> 0.7.3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -195,6 +195,7 @@ GEM
     thread_safe (0.3.5)
     tilt (1.4.1)
     timecop (0.7.3)
+    timeliness (0.3.7)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
@@ -202,6 +203,8 @@ GEM
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    validates_timeliness (3.0.14)
+      timeliness (~> 0.3.6)
     warden (1.2.3)
       rack (>= 1.0)
     web-console (2.1.2)
@@ -237,5 +240,6 @@ DEPENDENCIES
   timecop (~> 0.7.3)
   turbolinks
   uglifier (>= 1.3.0)
+  validates_timeliness (~> 3.0)
   web-console (~> 2.0)
   whenever

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
     capybara-webkit (1.5.1)
       capybara (>= 2.3.0, < 2.5.0)
       json
+    chronic (0.10.2)
     coderay (1.1.0)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
@@ -193,6 +194,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
+    timecop (0.7.3)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
@@ -207,6 +209,8 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    whenever (0.9.4)
+      chronic (>= 0.6.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -230,6 +234,8 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   slim-rails
   sqlite3
+  timecop (~> 0.7.3)
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  whenever

--- a/app/models/periodic_expense.rb
+++ b/app/models/periodic_expense.rb
@@ -11,7 +11,7 @@ class PeriodicExpense < ActiveRecord::Base
 
   scope :current, -> { where('start_date <= :today AND (end_date IS NULL OR end_date > :today)', today: Date.today) }
 
-  def ready_to_pay?
+  def due?
     !next_pay_on.future? && (end_date.nil? || end_date > Date.today)
   end
 

--- a/app/models/periodic_expense.rb
+++ b/app/models/periodic_expense.rb
@@ -1,12 +1,20 @@
 class PeriodicExpense < ActiveRecord::Base
-  PERIODS = %w(Weekly Monthly)
+  PERIODS = { 'weekly' => 1.week, 'monthly' => 1.month }
 
   belongs_to :user
 
   validates :name, :user, :amount, :period, :start_date, presence: true
-  validates :period, inclusion: { in: PERIODS }
+  validates :period, inclusion: { in: PERIODS.keys }
   validate :end_date_is_after_start_date
-  validate :last_created_at_is_between_start_and_end_dates
+  validate :last_paid_at_is_between_start_and_end_dates
+
+  def period_as_time
+    PERIODS[period]
+  end
+
+  def ready_to_pay?
+    !next_pay.future?
+  end
 
   private
 
@@ -16,13 +24,27 @@ class PeriodicExpense < ActiveRecord::Base
     errors.add(:end_date, 'cannot be before start date')
   end
 
-  def last_created_at_is_between_start_and_end_dates
-    return if last_created_at.blank? || between_start_and_end_dates?
+  def last_paid_at_is_between_start_and_end_dates
+    return if last_paid_at.blank? || between_start_and_end_dates?
 
     errors.add(:end_date, 'cannot be before start date')
   end
 
   def between_start_and_end_dates?
-    last_created_at > start_date && (end_date.blank? || last_created_at < end_date)
+    last_paid_at > start_date && (end_date.blank? || last_paid_at < end_date)
+  end
+
+  def next_pay
+    last_pay = last_paid_at
+
+    if last_pay.nil?
+      if period == 'weekly'
+        last_pay = start_date.beginning_of_week
+      elsif period == 'monthly'
+        last_pay = start_date.beginning_of_month
+      end
+    end
+
+    last_pay + period_as_time
   end
 end

--- a/app/models/periodic_expense.rb
+++ b/app/models/periodic_expense.rb
@@ -5,46 +5,33 @@ class PeriodicExpense < ActiveRecord::Base
 
   validates :name, :user, :amount, :period, :start_date, presence: true
   validates :period, inclusion: { in: PERIODS.keys }
-  validate :end_date_is_after_start_date
-  validate :last_paid_at_is_between_start_and_end_dates
+  validates_date :end_date, after: :start_date, if: :end_date
+  validates_date :last_paid_on, after: :start_date, if: :last_paid_on
+  validates_date :last_paid_on, before: :end_date, if: [:last_paid_on, :end_date]
 
-  def period_as_time
-    PERIODS[period]
-  end
+  scope :current, -> { where('start_date <= :today AND (end_date IS NULL OR end_date > :today)', today: Date.today) }
 
   def ready_to_pay?
-    !next_pay.future?
+    !next_pay_on.future? && (end_date.nil? || end_date > Date.today)
+  end
+
+  def at_beginning_of_period(date)
+    if period == 'weekly'
+      date.at_beginning_of_week
+    elsif period == 'monthly'
+      date.at_beginning_of_month
+    end
   end
 
   private
 
-  def end_date_is_after_start_date
-    return if end_date.blank? || end_date > start_date
-
-    errors.add(:end_date, 'cannot be before start date')
-  end
-
-  def last_paid_at_is_between_start_and_end_dates
-    return if last_paid_at.blank? || between_start_and_end_dates?
-
-    errors.add(:end_date, 'cannot be before start date')
-  end
-
-  def between_start_and_end_dates?
-    last_paid_at > start_date && (end_date.blank? || last_paid_at < end_date)
-  end
-
-  def next_pay
-    last_pay = last_paid_at
+  def next_pay_on
+    last_pay = last_paid_on
 
     if last_pay.nil?
-      if period == 'weekly'
-        last_pay = start_date.beginning_of_week
-      elsif period == 'monthly'
-        last_pay = start_date.beginning_of_month
-      end
+      last_pay = at_beginning_of_period(start_date)
     end
 
-    last_pay + period_as_time
+    last_pay + PERIODS[period]
   end
 end

--- a/app/models/periodic_expense.rb
+++ b/app/models/periodic_expense.rb
@@ -1,0 +1,28 @@
+class PeriodicExpense < ActiveRecord::Base
+  PERIODS = %w(Weekly Monthly)
+
+  belongs_to :user
+
+  validates :name, :user, :amount, :period, :start_date, presence: true
+  validates :period, inclusion: { in: PERIODS }
+  validate :end_date_is_after_start_date
+  validate :last_created_at_is_between_start_and_end_dates
+
+  private
+
+  def end_date_is_after_start_date
+    return if end_date.blank? || end_date > start_date
+
+    errors.add(:end_date, 'cannot be before start date')
+  end
+
+  def last_created_at_is_between_start_and_end_dates
+    return if last_created_at.blank? || between_start_and_end_dates?
+
+    errors.add(:end_date, 'cannot be before start date')
+  end
+
+  def between_start_and_end_dates?
+    last_created_at > start_date && (end_date.blank? || last_created_at < end_date)
+  end
+end

--- a/app/models/periodic_expense_runner.rb
+++ b/app/models/periodic_expense_runner.rb
@@ -12,7 +12,7 @@ class PeriodicExpenseRunner
   end
 
   def run_for_periodic_expense(periodic_expense)
-    return unless periodic_expense.ready_to_pay?
+    return unless periodic_expense.due?
 
     periodic_expense.transaction do
       update_periodic_expense(periodic_expense)

--- a/app/models/periodic_expense_runner.rb
+++ b/app/models/periodic_expense_runner.rb
@@ -6,23 +6,32 @@ class PeriodicExpenseRunner
   end
 
   def run
-    periodic_expenses.each do |periodic_expense|
+    PeriodicExpense.current.each do |periodic_expense|
+      run_for_periodic_expense(periodic_expense)
+    end
+  end
+
+  def run_for_periodic_expense(periodic_expense)
+    return unless periodic_expense.ready_to_pay?
+
+    periodic_expense.transaction do
+      update_periodic_expense(periodic_expense)
       create_expense(periodic_expense)
     end
   end
 
   private
 
-  def periodic_expenses
-    PeriodicExpense.where('start_date <= :today AND (end_date IS NULL OR end_date > :today)', today: today)
+  def update_periodic_expense(periodic_expense)
+    periodic_expense.update! last_paid_on: periodic_expense.at_beginning_of_period(today)
   end
 
   def create_expense(periodic_expense)
-    return unless periodic_expense.ready_to_pay?
-
-    name = "#{periodic_expense.name} (#{periodic_expense.period.downcase})"
-    periodic_expense.last_paid_at = today
-    expense = Expense.new(name: name, user: periodic_expense.user, date: today.to_datetime, value: periodic_expense.amount)
-    expense.save
+    Expense.create!(
+      name: "#{periodic_expense.name} (#{periodic_expense.period.downcase})",
+      user: periodic_expense.user,
+      date: today.to_datetime,
+      value: periodic_expense.amount
+    )
   end
 end

--- a/app/models/periodic_expense_runner.rb
+++ b/app/models/periodic_expense_runner.rb
@@ -1,0 +1,28 @@
+class PeriodicExpenseRunner
+  attr_accessor :today
+
+  def initialize
+    @today = Date.today
+  end
+
+  def run
+    periodic_expenses.each do |periodic_expense|
+      create_expense(periodic_expense)
+    end
+  end
+
+  private
+
+  def periodic_expenses
+    PeriodicExpense.where('start_date <= :today AND (end_date IS NULL OR end_date > :today)', today: today)
+  end
+
+  def create_expense(periodic_expense)
+    return unless periodic_expense.ready_to_pay?
+
+    name = "#{periodic_expense.name} (#{periodic_expense.period.downcase})"
+    periodic_expense.last_paid_at = today
+    expense = Expense.new(name: name, user: periodic_expense.user, date: today.to_datetime, value: periodic_expense.amount)
+    expense.save
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ActiveRecord::Base
   devise :database_authenticatable, :registerable, :recoverable, :rememberable, :trackable, :validatable
 
   has_many :expenses
+  has_many :periodic_expenses
 
   validates :name, :email, presence: true
   validates :email, uniqueness: true, format: { with: /\A\s*([-a-z0-9+._]{1,64})@((?:[-a-z0-9]+\.)+[a-z]{2,})\s*\z/i }

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,3 @@
+every 1.day do
+  rake 'periodic_expenses:run'
+end

--- a/db/migrate/20150428143744_create_periodic_expenses.rb
+++ b/db/migrate/20150428143744_create_periodic_expenses.rb
@@ -1,0 +1,13 @@
+class CreatePeriodicExpenses < ActiveRecord::Migration
+  def change
+    create_table :periodic_expenses do |t|
+      t.string :name
+      t.float :amount
+      t.string :period
+      t.integer :user_id
+      t.datetime :start_date
+      t.datetime :end_date
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20150428143744_create_periodic_expenses.rb
+++ b/db/migrate/20150428143744_create_periodic_expenses.rb
@@ -5,8 +5,8 @@ class CreatePeriodicExpenses < ActiveRecord::Migration
       t.float :amount
       t.string :period
       t.integer :user_id
-      t.datetime :start_date
-      t.datetime :end_date
+      t.date :start_date
+      t.date :end_date
       t.timestamps
     end
   end

--- a/db/migrate/20150428164540_add_last_created_at_to_periodic_expenses.rb
+++ b/db/migrate/20150428164540_add_last_created_at_to_periodic_expenses.rb
@@ -1,0 +1,5 @@
+class AddLastCreatedAtToPeriodicExpenses < ActiveRecord::Migration
+  def change
+    add_column :periodic_expenses, :last_created_at, :datetime
+  end
+end

--- a/db/migrate/20150428164540_add_last_created_at_to_periodic_expenses.rb
+++ b/db/migrate/20150428164540_add_last_created_at_to_periodic_expenses.rb
@@ -1,5 +1,5 @@
 class AddLastCreatedAtToPeriodicExpenses < ActiveRecord::Migration
   def change
-    add_column :periodic_expenses, :last_created_at, :datetime
+    add_column :periodic_expenses, :last_created_at, :date
   end
 end

--- a/db/migrate/20150429111605_change_last_created_at_to_last_paid_at.rb
+++ b/db/migrate/20150429111605_change_last_created_at_to_last_paid_at.rb
@@ -1,6 +1,6 @@
 class ChangeLastCreatedAtToLastPaidAt < ActiveRecord::Migration
   def change
-    remove_column :periodic_expenses, :last_created_at
+    remove_column :periodic_expenses, :last_created_at, :date
     add_column :periodic_expenses, :last_paid_at, :date
   end
 end

--- a/db/migrate/20150429111605_change_last_created_at_to_last_paid_at.rb
+++ b/db/migrate/20150429111605_change_last_created_at_to_last_paid_at.rb
@@ -1,0 +1,6 @@
+class ChangeLastCreatedAtToLastPaidAt < ActiveRecord::Migration
+  def change
+    remove_column :periodic_expenses, :last_created_at
+    add_column :periodic_expenses, :last_paid_at, :date
+  end
+end

--- a/db/migrate/20150430100801_change_last_paid_at_to_last_paid_on.rb
+++ b/db/migrate/20150430100801_change_last_paid_at_to_last_paid_on.rb
@@ -1,0 +1,6 @@
+class ChangeLastPaidAtToLastPaidOn < ActiveRecord::Migration
+  def change
+    remove_column :periodic_expenses, :last_paid_at, :date
+    add_column :periodic_expenses, :last_paid_on, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150427141241) do
+ActiveRecord::Schema.define(version: 20150428164540) do
 
   create_table "expenses", force: :cascade do |t|
     t.string   "name"
@@ -20,6 +20,18 @@ ActiveRecord::Schema.define(version: 20150427141241) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "user_id"
+  end
+
+  create_table "periodic_expenses", force: :cascade do |t|
+    t.string   "name"
+    t.float    "amount"
+    t.string   "period"
+    t.integer  "user_id"
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.datetime "last_created_at"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150429111605) do
+ActiveRecord::Schema.define(version: 20150430100801) do
 
   create_table "expenses", force: :cascade do |t|
     t.string   "name"
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 20150429111605) do
     t.datetime "end_date"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.date     "last_paid_at"
+    t.date     "last_paid_on"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150428164540) do
+ActiveRecord::Schema.define(version: 20150429111605) do
 
   create_table "expenses", force: :cascade do |t|
     t.string   "name"
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 20150428164540) do
     t.datetime "end_date"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.datetime "last_created_at"
+    t.date     "last_paid_at"
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/tasks/periodic_expenses.rake
+++ b/lib/tasks/periodic_expenses.rake
@@ -1,0 +1,5 @@
+namespace :periodic_expenses do
+  task :run => :environment do
+    PeriodicExpenseRunner.new.run
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -17,7 +17,7 @@ FactoryGirl.define do
     name 'Jantar'
     value 100
     date { DateTime.now }
-    user
+    association :user, factory: :user, strategy: :build
   end
 
   factory :periodic_expense do
@@ -25,6 +25,6 @@ FactoryGirl.define do
     amount 25
     period 'monthly'
     start_date { Date.today }
-    user
+    association :user, factory: :user, strategy: :build
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -23,9 +23,8 @@ FactoryGirl.define do
   factory :periodic_expense do
     name 'Github'
     amount 25
-    period 'Monthly'
-    start_date { DateTime.now }
-    end_date { DateTime.now + 5.months }
+    period 'monthly'
+    start_date { Date.today }
     user
   end
 end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -19,4 +19,13 @@ FactoryGirl.define do
     date { DateTime.now }
     user
   end
+
+  factory :periodic_expense do
+    name 'Github'
+    amount 25
+    period 'Monthly'
+    start_date { DateTime.now }
+    end_date { DateTime.now + 5.months }
+    user
+  end
 end

--- a/spec/models/periodic_expense_runner_spec.rb
+++ b/spec/models/periodic_expense_runner_spec.rb
@@ -3,27 +3,71 @@ require 'rails_helper'
 describe PeriodicExpenseRunner, type: :model do
   let(:runner) { PeriodicExpenseRunner.new }
 
-  context '#run' do
+  context '#run_for_periodic_expense' do
     context 'monthly expense' do
       context 'last paid over a month ago' do
         it 'creates an expense' do
-          last_pay = Date.new(2015, 2, 1)
-          create(:periodic_expense, start_date: last_pay.prev_month, period: 'monthly', last_paid_at: last_pay)
+          last_paid_on = Date.new(2015, 2, 1)
+          periodic_expense = create(:periodic_expense, start_date: last_paid_on.prev_month, period: 'monthly', last_paid_on: last_paid_on)
 
-          Timecop.freeze(last_pay.next_month)
+          Timecop.freeze(last_paid_on.next_month)
 
-          expect { runner.run }.to change { Expense.count }.by(1)
+          expect { runner.run_for_periodic_expense(periodic_expense) }.to change { Expense.count }.by(1)
         end
       end
 
       context 'last paid less than a month ago' do
         it 'does not create an expense' do
-          last_pay = Date.new(2015, 2, 1)
-          create(:periodic_expense, start_date: last_pay.prev_month, period: 'monthly', last_paid_at: last_pay)
+          last_paid_on = Date.new(2015, 2, 1)
+          periodic_expense = create(:periodic_expense, start_date: last_paid_on.prev_month, period: 'monthly', last_paid_on: last_paid_on)
 
-          Timecop.freeze(last_pay.next_week)
+          Timecop.freeze(last_paid_on.next_week)
 
-          expect { runner.run }.to change { Expense.count }.by(0)
+          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
+        end
+      end
+
+      context 'with a start date in the future' do
+        it 'does not create an expense' do
+          today = Date.new(2015, 2, 1)
+          periodic_expense = create(:periodic_expense, start_date: today.next_month, period: 'monthly')
+
+          Timecop.freeze(today)
+
+          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
+        end
+      end
+
+      context 'with an end date in the past' do
+        it 'does not create an expense' do
+          today = Date.new(2015, 2, 1)
+          periodic_expense = create(:periodic_expense, start_date: today - 5.months, end_date: today - 2.months, period: 'monthly', last_paid_on: today - 3.months)
+
+          Timecop.freeze(today)
+
+          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
+        end
+      end
+
+      context 'in the beginning of the month after creation' do
+        it 'creates an expense ' do
+          created_on = Date.new(2015, 2, 15)
+          periodic_expense = create(:periodic_expense, start_date: created_on, period: 'monthly')
+
+          Timecop.freeze(created_on.next_month.at_beginning_of_month)
+
+          expect { runner.run_for_periodic_expense(periodic_expense) }.to change { Expense.count }.by(1)
+        end
+      end
+
+      context 'in the same month it was created' do
+        it 'does not create an expense' do
+          created_on = Date.new(2015, 2, 15)
+          periodic_expense = create(:periodic_expense, start_date: created_on, period: 'monthly')
+
+          Timecop.freeze(created_on.next_week)
+
+          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
         end
       end
     end
@@ -31,30 +75,102 @@ describe PeriodicExpenseRunner, type: :model do
     context 'weekly expense' do
       context 'last paid over a week ago' do
         it 'creates an expense' do
-          create(:periodic_expense, start_date: Date.new(2015, 1, 22), period: 'weekly', last_paid_at: Date.new(2015, 1, 26))
+          last_paid_on = Date.new(2015, 2, 1).beginning_of_week
+          periodic_expense = create(:periodic_expense, start_date: last_paid_on.prev_month, period: 'weekly', last_paid_on: last_paid_on)
 
-          Timecop.freeze(Date.new(2015, 2, 2))
+          Timecop.freeze(last_paid_on.next_week)
 
-          expect { runner.run }.to change { Expense.count }.by(1)
+          expect { runner.run_for_periodic_expense(periodic_expense) }.to change { Expense.count }.by(1)
         end
       end
 
       context 'last paid less than a week ago' do
         it 'does not create an expense' do
-          create(:periodic_expense, start_date: Date.new(2015, 1, 22), period: 'weekly', last_paid_at: Date.new(2015, 1, 26))
+          last_paid_on = Date.new(2015, 2, 1).beginning_of_week
+          periodic_expense = create(:periodic_expense, start_date: last_paid_on.prev_month, period: 'weekly', last_paid_on: last_paid_on)
 
-          Timecop.freeze(Date.new(2015, 1, 28))
+          Timecop.freeze(last_paid_on.next_day)
 
-          expect { runner.run }.to change { Expense.count }.by(0)
+          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
+        end
+      end
+
+      context 'with a start date in the future' do
+        it 'does not create an expense' do
+          today = Date.new(2015, 2, 1)
+          periodic_expense = create(:periodic_expense, start_date: today.next_month, period: 'weekly')
+
+          Timecop.freeze(today)
+
+          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
+        end
+      end
+
+      context 'with an end date in the past' do
+        it 'does not create an expense' do
+          today = Date.new(2015, 2, 1)
+          periodic_expense = create(:periodic_expense, start_date: today - 5.months, end_date: today - 2.months, period: 'weekly', last_paid_on: today - 3.months)
+
+          Timecop.freeze(today)
+
+          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
+        end
+      end
+
+      context 'in the beginning of the week after creation' do
+        it 'creates an expense ' do
+          created_on = Date.new(2015, 2, 15)
+          periodic_expense = create(:periodic_expense, start_date: created_on, period: 'weekly')
+
+          Timecop.freeze(created_on.next_week.at_beginning_of_week)
+
+          expect { runner.run_for_periodic_expense(periodic_expense) }.to change { Expense.count }.by(1)
+        end
+      end
+
+      context 'in the same week it was created' do
+        it 'does not create an expense' do
+          created_on = Date.new(2015, 2, 15).beginning_of_week.next_day
+          periodic_expense = create(:periodic_expense, start_date: created_on, period: 'weekly')
+
+          Timecop.freeze(created_on.next_day)
+
+          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
         end
       end
     end
+  end
 
-    context 'no periodic expenses' do
+  context '#run' do
+    context 'with no periodic expenses' do
       it 'does not create expenses' do
         runner.run
 
         expect(Expense.count).to eq 0
+      end
+    end
+
+    context 'with periodic expenses that are ready to pay' do
+      it 'creates expenses' do
+        today = Date.new(2015, 3, 1).next_week.beginning_of_week
+        create(:periodic_expense, start_date: today - 2.months, period: 'monthly', last_paid_on: today.prev_month.beginning_of_month)
+        create(:periodic_expense, start_date: today - 2.months, period: 'weekly', last_paid_on: today.prev_week)
+
+        Timecop.freeze(today)
+
+        expect { runner.run }.to change { Expense.count }.by(2)
+      end
+
+      it 'updates those periodic expenses' do
+        today = Date.new(2015, 3, 1).next_week.beginning_of_week
+        periodic_expense1 = create(:periodic_expense, start_date: today - 2.months, period: 'monthly', last_paid_on: today.prev_month.beginning_of_month)
+        periodic_expense2 = create(:periodic_expense, start_date: today - 2.months, period: 'weekly', last_paid_on: today.prev_week)
+
+        Timecop.freeze(today)
+        runner.run
+
+        expect(periodic_expense1.reload).not_to be_ready_to_pay
+        expect(periodic_expense2.reload).not_to be_ready_to_pay
       end
     end
   end

--- a/spec/models/periodic_expense_runner_spec.rb
+++ b/spec/models/periodic_expense_runner_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+describe PeriodicExpenseRunner, type: :model do
+  let(:runner) { PeriodicExpenseRunner.new }
+
+  context '#run' do
+    context 'monthly expense' do
+      context 'last paid over a month ago' do
+        it 'creates an expense' do
+          last_pay = Date.new(2015, 2, 1)
+          create(:periodic_expense, start_date: last_pay.prev_month, period: 'monthly', last_paid_at: last_pay)
+
+          Timecop.freeze(last_pay.next_month)
+
+          expect { runner.run }.to change { Expense.count }.by(1)
+        end
+      end
+
+      context 'last paid less than a month ago' do
+        it 'does not create an expense' do
+          last_pay = Date.new(2015, 2, 1)
+          create(:periodic_expense, start_date: last_pay.prev_month, period: 'monthly', last_paid_at: last_pay)
+
+          Timecop.freeze(last_pay.next_week)
+
+          expect { runner.run }.to change { Expense.count }.by(0)
+        end
+      end
+    end
+
+    context 'weekly expense' do
+      context 'last paid over a week ago' do
+        it 'creates an expense' do
+          create(:periodic_expense, start_date: Date.new(2015, 1, 22), period: 'weekly', last_paid_at: Date.new(2015, 1, 26))
+
+          Timecop.freeze(Date.new(2015, 2, 2))
+
+          expect { runner.run }.to change { Expense.count }.by(1)
+        end
+      end
+
+      context 'last paid less than a week ago' do
+        it 'does not create an expense' do
+          create(:periodic_expense, start_date: Date.new(2015, 1, 22), period: 'weekly', last_paid_at: Date.new(2015, 1, 26))
+
+          Timecop.freeze(Date.new(2015, 1, 28))
+
+          expect { runner.run }.to change { Expense.count }.by(0)
+        end
+      end
+    end
+
+    context 'no periodic expenses' do
+      it 'does not create expenses' do
+        runner.run
+
+        expect(Expense.count).to eq 0
+      end
+    end
+  end
+end

--- a/spec/models/periodic_expense_runner_spec.rb
+++ b/spec/models/periodic_expense_runner_spec.rb
@@ -26,11 +26,11 @@ describe PeriodicExpenseRunner, type: :model do
 
   context '#run' do
     it 'calls run_for_periodic_expense for each periodic expense' do
-      allow(PeriodicExpense).to receive(:current).and_return([1, 2, 3])
+      periodic_expense = instance_double('PeriodicExpense')
+      allow(PeriodicExpense).to receive(:current).and_return([periodic_expense, periodic_expense])
 
-      expect(runner).to receive(:run_for_periodic_expense).with(1)
-      expect(runner).to receive(:run_for_periodic_expense).with(2)
-      expect(runner).to receive(:run_for_periodic_expense).with(3)
+      expect(runner).to receive(:run_for_periodic_expense).with(periodic_expense)
+      expect(runner).to receive(:run_for_periodic_expense).with(periodic_expense)
 
       runner.run
     end

--- a/spec/models/periodic_expense_runner_spec.rb
+++ b/spec/models/periodic_expense_runner_spec.rb
@@ -4,8 +4,8 @@ describe PeriodicExpenseRunner, type: :model do
   let(:runner) { PeriodicExpenseRunner.new }
 
   context '#run_for_periodic_expense' do
-    context 'monthly expense' do
-      context 'last paid over a month ago' do
+    context 'with a periodic expense' do
+      context 'that is ready to pay' do
         it 'creates an expense' do
           last_paid_on = Date.new(2015, 2, 1)
           periodic_expense = create(:periodic_expense, start_date: last_paid_on.prev_month, period: 'monthly', last_paid_on: last_paid_on)
@@ -16,124 +16,12 @@ describe PeriodicExpenseRunner, type: :model do
         end
       end
 
-      context 'last paid less than a month ago' do
+      context 'that is not ready to pay' do
         it 'does not create an expense' do
           last_paid_on = Date.new(2015, 2, 1)
           periodic_expense = create(:periodic_expense, start_date: last_paid_on.prev_month, period: 'monthly', last_paid_on: last_paid_on)
 
           Timecop.freeze(last_paid_on.next_week)
-
-          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
-        end
-      end
-
-      context 'with a start date in the future' do
-        it 'does not create an expense' do
-          today = Date.new(2015, 2, 1)
-          periodic_expense = create(:periodic_expense, start_date: today.next_month, period: 'monthly')
-
-          Timecop.freeze(today)
-
-          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
-        end
-      end
-
-      context 'with an end date in the past' do
-        it 'does not create an expense' do
-          today = Date.new(2015, 2, 1)
-          periodic_expense = create(:periodic_expense, start_date: today - 5.months, end_date: today - 2.months, period: 'monthly', last_paid_on: today - 3.months)
-
-          Timecop.freeze(today)
-
-          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
-        end
-      end
-
-      context 'in the beginning of the month after creation' do
-        it 'creates an expense ' do
-          created_on = Date.new(2015, 2, 15)
-          periodic_expense = create(:periodic_expense, start_date: created_on, period: 'monthly')
-
-          Timecop.freeze(created_on.next_month.at_beginning_of_month)
-
-          expect { runner.run_for_periodic_expense(periodic_expense) }.to change { Expense.count }.by(1)
-        end
-      end
-
-      context 'in the same month it was created' do
-        it 'does not create an expense' do
-          created_on = Date.new(2015, 2, 15)
-          periodic_expense = create(:periodic_expense, start_date: created_on, period: 'monthly')
-
-          Timecop.freeze(created_on.next_week)
-
-          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
-        end
-      end
-    end
-
-    context 'weekly expense' do
-      context 'last paid over a week ago' do
-        it 'creates an expense' do
-          last_paid_on = Date.new(2015, 2, 1).beginning_of_week
-          periodic_expense = create(:periodic_expense, start_date: last_paid_on.prev_month, period: 'weekly', last_paid_on: last_paid_on)
-
-          Timecop.freeze(last_paid_on.next_week)
-
-          expect { runner.run_for_periodic_expense(periodic_expense) }.to change { Expense.count }.by(1)
-        end
-      end
-
-      context 'last paid less than a week ago' do
-        it 'does not create an expense' do
-          last_paid_on = Date.new(2015, 2, 1).beginning_of_week
-          periodic_expense = create(:periodic_expense, start_date: last_paid_on.prev_month, period: 'weekly', last_paid_on: last_paid_on)
-
-          Timecop.freeze(last_paid_on.next_day)
-
-          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
-        end
-      end
-
-      context 'with a start date in the future' do
-        it 'does not create an expense' do
-          today = Date.new(2015, 2, 1)
-          periodic_expense = create(:periodic_expense, start_date: today.next_month, period: 'weekly')
-
-          Timecop.freeze(today)
-
-          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
-        end
-      end
-
-      context 'with an end date in the past' do
-        it 'does not create an expense' do
-          today = Date.new(2015, 2, 1)
-          periodic_expense = create(:periodic_expense, start_date: today - 5.months, end_date: today - 2.months, period: 'weekly', last_paid_on: today - 3.months)
-
-          Timecop.freeze(today)
-
-          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
-        end
-      end
-
-      context 'in the beginning of the week after creation' do
-        it 'creates an expense ' do
-          created_on = Date.new(2015, 2, 15)
-          periodic_expense = create(:periodic_expense, start_date: created_on, period: 'weekly')
-
-          Timecop.freeze(created_on.next_week.at_beginning_of_week)
-
-          expect { runner.run_for_periodic_expense(periodic_expense) }.to change { Expense.count }.by(1)
-        end
-      end
-
-      context 'in the same week it was created' do
-        it 'does not create an expense' do
-          created_on = Date.new(2015, 2, 15).beginning_of_week.next_day
-          periodic_expense = create(:periodic_expense, start_date: created_on, period: 'weekly')
-
-          Timecop.freeze(created_on.next_day)
 
           expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
         end

--- a/spec/models/periodic_expense_spec.rb
+++ b/spec/models/periodic_expense_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+describe PeriodicExpense, type: :model do
+  context '#valid?' do
+    it 'is valid when all fields are present' do
+      periodic_expense = build(:periodic_expense)
+
+      expect(periodic_expense).to be_valid
+    end
+
+    it 'must have a valid period' do
+      periodic_expense = build(:periodic_expense, period: 'Something')
+
+      expect(periodic_expense).not_to be_valid
+    end
+
+    context 'end_date is after start_date' do
+      it 'is valid' do
+        periodic_expense = build(:periodic_expense, start_date: DateTime.yesterday, end_date: DateTime.tomorrow)
+
+        expect(periodic_expense).to be_valid
+      end
+
+      context 'last_created_at is between start_date and end_date' do
+        it 'is valid' do
+          periodic_expense = build(:periodic_expense, start_date: DateTime.now, end_date: DateTime.now + 5.months, last_created_at: DateTime.now + 1.months)
+
+          expect(periodic_expense).to be_valid
+        end
+      end
+
+      context 'last_created_at is after end_date' do
+        it 'is invalid' do
+          periodic_expense = build(:periodic_expense)
+          periodic_expense.last_created_at = periodic_expense.end_date + 2.months
+
+          expect(periodic_expense).not_to be_valid
+        end
+      end
+
+      context 'last_created_at is before start_date' do
+        it 'is invalid' do
+          periodic_expense = build(:periodic_expense)
+          periodic_expense.last_created_at = periodic_expense.start_date - 2.months
+
+          expect(periodic_expense).not_to be_valid
+        end
+      end
+    end
+
+    context 'end_date is before start_date' do
+      it 'is invalid' do
+        periodic_expense = build(:periodic_expense, start_date: DateTime.tomorrow, end_date: DateTime.yesterday)
+
+        expect(periodic_expense).not_to be_valid
+      end
+    end
+
+    context 'there is no end_date' do
+      it 'is valid' do
+        periodic_expense = build(:periodic_expense, end_date: nil)
+
+        expect(periodic_expense).to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/periodic_expense_spec.rb
+++ b/spec/models/periodic_expense_spec.rb
@@ -70,7 +70,7 @@ describe PeriodicExpense, type: :model do
     end
   end
 
-  context '#ready_to_pay?' do
+  context '#due?' do
     context 'monthly expense' do
       context 'last paid over a month ago' do
         it 'returns true' do
@@ -80,7 +80,7 @@ describe PeriodicExpense, type: :model do
 
           Timecop.freeze(today)
 
-          expect(periodic_expense.ready_to_pay?).to be true
+          expect(periodic_expense.due?).to be true
         end
       end
 
@@ -92,7 +92,7 @@ describe PeriodicExpense, type: :model do
 
           Timecop.freeze(today)
 
-          expect(periodic_expense.ready_to_pay?).to be false
+          expect(periodic_expense.due?).to be false
         end
       end
     end
@@ -106,7 +106,7 @@ describe PeriodicExpense, type: :model do
 
           Timecop.freeze(today)
 
-          expect(periodic_expense.ready_to_pay?).to be true
+          expect(periodic_expense.due?).to be true
         end
       end
 
@@ -118,8 +118,26 @@ describe PeriodicExpense, type: :model do
 
           Timecop.freeze(today)
 
-          expect(periodic_expense.ready_to_pay?).to be false
+          expect(periodic_expense.due?).to be false
         end
+      end
+    end
+  end
+
+  context '#current' do
+    context 'with active and inactive periodic expenses' do
+      it 'returns only the active periodic expenses' do
+        today = Date.new(2015, 3, 1).next_week.beginning_of_week
+        active1 = create(:periodic_expense, start_date: today - 2.months)
+        active2 = create(:periodic_expense, start_date: today.last_month, end_date: today.next_month)
+        inactive1 = create(:periodic_expense, start_date: today.next_month)
+        inactive2 = create(:periodic_expense, start_date: today - 3.months, end_date: today.last_month)
+
+        Timecop.freeze(today)
+        current = PeriodicExpense.current
+
+        expect(current).to contain_exactly(active1, active2)
+        expect(current).not_to include(inactive1, inactive2)
       end
     end
   end

--- a/spec/models/periodic_expense_spec.rb
+++ b/spec/models/periodic_expense_spec.rb
@@ -14,53 +14,112 @@ describe PeriodicExpense, type: :model do
       expect(periodic_expense).not_to be_valid
     end
 
-    context 'end_date is after start_date' do
-      it 'is valid' do
-        periodic_expense = build(:periodic_expense, start_date: DateTime.yesterday, end_date: DateTime.tomorrow)
-
-        expect(periodic_expense).to be_valid
-      end
-
-      context 'last_created_at is between start_date and end_date' do
+    context 'end_date' do
+      context 'after start_date' do
         it 'is valid' do
-          periodic_expense = build(:periodic_expense, start_date: DateTime.now, end_date: DateTime.now + 5.months, last_created_at: DateTime.now + 1.months)
+          periodic_expense = build(:periodic_expense, start_date: DateTime.yesterday, end_date: DateTime.tomorrow)
 
           expect(periodic_expense).to be_valid
         end
       end
 
-      context 'last_created_at is after end_date' do
+      context 'before start_date' do
         it 'is invalid' do
-          periodic_expense = build(:periodic_expense)
-          periodic_expense.last_created_at = periodic_expense.end_date + 2.months
+          periodic_expense = build(:periodic_expense, start_date: DateTime.tomorrow, end_date: DateTime.yesterday)
 
           expect(periodic_expense).not_to be_valid
         end
       end
 
-      context 'last_created_at is before start_date' do
+      context 'absent' do
+        it 'is valid' do
+          periodic_expense = build(:periodic_expense, end_date: nil)
+
+          expect(periodic_expense).to be_valid
+        end
+      end
+    end
+
+    context 'last_paid_at' do
+      context 'between start_date and end_date' do
+        it 'is valid' do
+          start_date = DateTime.now
+          periodic_expense = build(:periodic_expense, start_date: start_date, end_date: start_date + 5.months, last_paid_at: start_date + 1.months)
+
+          expect(periodic_expense).to be_valid
+        end
+      end
+
+      context 'after end_date' do
         it 'is invalid' do
-          periodic_expense = build(:periodic_expense)
-          periodic_expense.last_created_at = periodic_expense.start_date - 2.months
+          end_date = DateTime.now + 5.months
+          periodic_expense = build(:periodic_expense, end_date: end_date, last_paid_at: end_date + 1.months)
+
+          expect(periodic_expense).not_to be_valid
+        end
+      end
+
+      context 'before start_date' do
+        it 'is invalid' do
+          start_date = DateTime.now
+          periodic_expense = build(:periodic_expense, start_date: start_date, last_paid_at: start_date - 2.months)
 
           expect(periodic_expense).not_to be_valid
         end
       end
     end
+  end
 
-    context 'end_date is before start_date' do
-      it 'is invalid' do
-        periodic_expense = build(:periodic_expense, start_date: DateTime.tomorrow, end_date: DateTime.yesterday)
+  context '#ready_to_pay?' do
+    context 'monthly expense' do
+      context 'last paid over a month ago' do
+        it 'returns true' do
+          last_pay = Date.new(2015, 2, 1)
+          periodic_expense = build(:periodic_expense, start_date: last_pay.prev_month, period: 'monthly', last_paid_at: last_pay)
+          today = last_pay.next_month
 
-        expect(periodic_expense).not_to be_valid
+          Timecop.freeze(today)
+
+          expect(periodic_expense.ready_to_pay?).to be true
+        end
+      end
+
+      context 'last paid less than a month ago' do
+        it 'returns false' do
+          last_pay = Date.new(2015, 2, 1)
+          periodic_expense = build(:periodic_expense, start_date: last_pay.prev_month, period: 'monthly', last_paid_at: last_pay)
+          today = last_pay.next_week
+
+          Timecop.freeze(today)
+
+          expect(periodic_expense.ready_to_pay?).to be false
+        end
       end
     end
 
-    context 'there is no end_date' do
-      it 'is valid' do
-        periodic_expense = build(:periodic_expense, end_date: nil)
+    context 'weekly expense' do
+      context 'last paid over a week ago' do
+        it 'returns true' do
+          last_pay = Date.new(2015, 2, 1).beginning_of_week
+          periodic_expense = build(:periodic_expense, start_date: last_pay.prev_month, period: 'weekly', last_paid_at: last_pay)
+          today = last_pay.next_week
 
-        expect(periodic_expense).to be_valid
+          Timecop.freeze(today)
+
+          expect(periodic_expense.ready_to_pay?).to be true
+        end
+      end
+
+      context 'last paid less than a week ago' do
+        it 'returns false' do
+          last_pay = Date.new(2015, 2, 1).beginning_of_week
+          periodic_expense = build(:periodic_expense, start_date: last_pay.prev_month, period: 'weekly', last_paid_at: last_pay)
+          today = last_pay.next_day
+
+          Timecop.freeze(today)
+
+          expect(periodic_expense.ready_to_pay?).to be false
+        end
       end
     end
   end

--- a/spec/models/periodic_expense_spec.rb
+++ b/spec/models/periodic_expense_spec.rb
@@ -80,7 +80,7 @@ describe PeriodicExpense, type: :model do
 
           Timecop.freeze(today)
 
-          expect(periodic_expense.due?).to be true
+          expect(periodic_expense).to be_due
         end
       end
 
@@ -92,7 +92,7 @@ describe PeriodicExpense, type: :model do
 
           Timecop.freeze(today)
 
-          expect(periodic_expense.due?).to be false
+          expect(periodic_expense).not_to be_due
         end
       end
     end
@@ -106,7 +106,7 @@ describe PeriodicExpense, type: :model do
 
           Timecop.freeze(today)
 
-          expect(periodic_expense.due?).to be true
+          expect(periodic_expense).to be_due
         end
       end
 
@@ -118,7 +118,7 @@ describe PeriodicExpense, type: :model do
 
           Timecop.freeze(today)
 
-          expect(periodic_expense.due?).to be false
+          expect(periodic_expense).not_to be_due
         end
       end
     end

--- a/spec/models/periodic_expense_spec.rb
+++ b/spec/models/periodic_expense_spec.rb
@@ -40,11 +40,11 @@ describe PeriodicExpense, type: :model do
       end
     end
 
-    context 'last_paid_at' do
+    context 'last_paid_on' do
       context 'between start_date and end_date' do
         it 'is valid' do
           start_date = DateTime.now
-          periodic_expense = build(:periodic_expense, start_date: start_date, end_date: start_date + 5.months, last_paid_at: start_date + 1.months)
+          periodic_expense = build(:periodic_expense, start_date: start_date, end_date: start_date + 5.months, last_paid_on: start_date + 1.months)
 
           expect(periodic_expense).to be_valid
         end
@@ -53,7 +53,7 @@ describe PeriodicExpense, type: :model do
       context 'after end_date' do
         it 'is invalid' do
           end_date = DateTime.now + 5.months
-          periodic_expense = build(:periodic_expense, end_date: end_date, last_paid_at: end_date + 1.months)
+          periodic_expense = build(:periodic_expense, end_date: end_date, last_paid_on: end_date + 1.months)
 
           expect(periodic_expense).not_to be_valid
         end
@@ -62,7 +62,7 @@ describe PeriodicExpense, type: :model do
       context 'before start_date' do
         it 'is invalid' do
           start_date = DateTime.now
-          periodic_expense = build(:periodic_expense, start_date: start_date, last_paid_at: start_date - 2.months)
+          periodic_expense = build(:periodic_expense, start_date: start_date, last_paid_on: start_date - 2.months)
 
           expect(periodic_expense).not_to be_valid
         end
@@ -74,9 +74,9 @@ describe PeriodicExpense, type: :model do
     context 'monthly expense' do
       context 'last paid over a month ago' do
         it 'returns true' do
-          last_pay = Date.new(2015, 2, 1)
-          periodic_expense = build(:periodic_expense, start_date: last_pay.prev_month, period: 'monthly', last_paid_at: last_pay)
-          today = last_pay.next_month
+          last_paid_on = Date.new(2015, 2, 1)
+          periodic_expense = build(:periodic_expense, start_date: last_paid_on.prev_month, period: 'monthly', last_paid_on: last_paid_on)
+          today = last_paid_on.next_month
 
           Timecop.freeze(today)
 
@@ -86,9 +86,9 @@ describe PeriodicExpense, type: :model do
 
       context 'last paid less than a month ago' do
         it 'returns false' do
-          last_pay = Date.new(2015, 2, 1)
-          periodic_expense = build(:periodic_expense, start_date: last_pay.prev_month, period: 'monthly', last_paid_at: last_pay)
-          today = last_pay.next_week
+          last_paid_on = Date.new(2015, 2, 1)
+          periodic_expense = build(:periodic_expense, start_date: last_paid_on.prev_month, period: 'monthly', last_paid_on: last_paid_on)
+          today = last_paid_on.next_week
 
           Timecop.freeze(today)
 
@@ -100,9 +100,9 @@ describe PeriodicExpense, type: :model do
     context 'weekly expense' do
       context 'last paid over a week ago' do
         it 'returns true' do
-          last_pay = Date.new(2015, 2, 1).beginning_of_week
-          periodic_expense = build(:periodic_expense, start_date: last_pay.prev_month, period: 'weekly', last_paid_at: last_pay)
-          today = last_pay.next_week
+          last_paid_on = Date.new(2015, 2, 1).beginning_of_week
+          periodic_expense = build(:periodic_expense, start_date: last_paid_on.prev_month, period: 'weekly', last_paid_on: last_paid_on)
+          today = last_paid_on.next_week
 
           Timecop.freeze(today)
 
@@ -112,9 +112,9 @@ describe PeriodicExpense, type: :model do
 
       context 'last paid less than a week ago' do
         it 'returns false' do
-          last_pay = Date.new(2015, 2, 1).beginning_of_week
-          periodic_expense = build(:periodic_expense, start_date: last_pay.prev_month, period: 'weekly', last_paid_at: last_pay)
-          today = last_pay.next_day
+          last_paid_on = Date.new(2015, 2, 1).beginning_of_week
+          periodic_expense = build(:periodic_expense, start_date: last_paid_on.prev_month, period: 'weekly', last_paid_on: last_paid_on)
+          today = last_paid_on.next_day
 
           Timecop.freeze(today)
 

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,3 +1,12 @@
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
+
+  config.before(:suite) do
+    begin
+      DatabaseCleaner.start
+      FactoryGirl.lint
+    ensure
+      DatabaseCleaner.clean
+    end
+  end
 end


### PR DESCRIPTION
Adds Periodic Expenses, used to trigger periodic creation of Expenses.

Also adds a rake task (periodic_expenses:run) that goes through all periodic expenses. This task is scheduled to run every day.
