### PR TITLE
Replaces validates_timeliness with date_validator.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,10 +29,10 @@ gem 'turbolinks'
 # gem 'capistrano-rails', group: :development
 
 gem 'cancancan', '~> 1.10'
+gem 'date_validator'
 gem 'devise'
 gem 'simple_form'
 gem 'slim-rails'
-gem 'validates_timeliness', '~> 3.0'
 gem 'whenever'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,8 @@ GEM
     coffee-script-source (1.9.1.1)
     columnize (0.9.0)
     database_cleaner (1.4.0)
+    date_validator (0.7.1)
+      activemodel
     debug_inspector (0.0.2)
     devise (3.4.1)
       bcrypt (~> 3.0)
@@ -202,7 +204,6 @@ GEM
     thread_safe (0.3.5)
     tilt (1.4.1)
     timecop (0.7.3)
-    timeliness (0.3.7)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
@@ -210,8 +211,6 @@ GEM
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
-    validates_timeliness (3.0.14)
-      timeliness (~> 0.3.6)
     warden (1.2.3)
       rack (>= 1.0)
     web-console (2.1.2)
@@ -234,6 +233,7 @@ DEPENDENCIES
   capybara-webkit
   coffee-rails (~> 4.1.0)
   database_cleaner
+  date_validator
   devise
   factory_girl_rails (~> 4.2)
   formulaic
@@ -249,6 +249,5 @@ DEPENDENCIES
   timecop (~> 0.7.3)
   turbolinks
   uglifier (>= 1.3.0)
-  validates_timeliness (~> 3.0)
   web-console (~> 2.0)
   whenever

--- a/app/models/periodic_expense.rb
+++ b/app/models/periodic_expense.rb
@@ -6,9 +6,9 @@ class PeriodicExpense < ActiveRecord::Base
 
   validates :name, :user, :amount, :period, :start_date, presence: true
   validates :period, inclusion: { in: PERIODS.keys }
-  validates_date :end_date, after: :start_date, if: :end_date
-  validates_date :last_paid_on, after: :start_date, if: :last_paid_on
-  validates_date :last_paid_on, before: :end_date, if: [:last_paid_on, :end_date]
+  validates :end_date, date: { after: :start_date }, if: :end_date
+  validates :last_paid_on, date: { after: :start_date }, if: :last_paid_on
+  validates :last_paid_on, date: { before: :end_date }, if: [:last_paid_on, :end_date]
 
   scope :current, -> { where('start_date <= :today AND (end_date IS NULL OR end_date > :today)', today: Date.today) }
 


### PR DESCRIPTION
This date validator gem is more recent than validates timeliness and uses a syntax similar to Rails' validators.
