### PR TITLE
Reminders.

### DIFF
--- a/app/models/periodic_expense.rb
+++ b/app/models/periodic_expense.rb
@@ -28,13 +28,13 @@ class PeriodicExpense < ActiveRecord::Base
     end
   end
 
-  def create_expense
-    Expense.create!(
-      name: "#{name} (#{period.downcase})",
+  def create_reminder
+    due_on = next_pay_on
+    Reminder.create!(
+      message: "#{name} is due #{due_on}.",
+      due_on: due_on,
       user: user,
-      periodic_expense: self,
-      paid_on: Date.today,
-      amount: amount
+      periodic_expense: self
     )
   end
 

--- a/app/models/periodic_expense_runner.rb
+++ b/app/models/periodic_expense_runner.rb
@@ -16,7 +16,7 @@ class PeriodicExpenseRunner
 
     periodic_expense.transaction do
       update_periodic_expense(periodic_expense)
-      create_expense(periodic_expense)
+      create_reminder(periodic_expense)
     end
   end
 
@@ -26,7 +26,7 @@ class PeriodicExpenseRunner
     periodic_expense.update! last_paid_on: periodic_expense.at_beginning_of_period(today)
   end
 
-  def create_expense(periodic_expense)
-    periodic_expense.create_expense
+  def create_reminder(periodic_expense)
+    periodic_expense.create_reminder
   end
 end

--- a/app/models/reminder.rb
+++ b/app/models/reminder.rb
@@ -1,0 +1,6 @@
+class Reminder < ActiveRecord::Base
+  belongs_to :user
+  belongs_to :periodic_expense
+
+  validates :message, :due_on, :user, :periodic_expense, presence: true
+end

--- a/db/migrate/20150515093642_create_reminder.rb
+++ b/db/migrate/20150515093642_create_reminder.rb
@@ -1,0 +1,12 @@
+class CreateReminder < ActiveRecord::Migration
+  def change
+    create_table :reminders do |t|
+      t.string :message
+      t.belongs_to :user, index: true
+      t.date :due_on
+      t.belongs_to :periodic_expense, index: true
+    end
+    add_foreign_key :reminders, :users
+    add_foreign_key :reminders, :periodic_expenses
+  end
+end

--- a/db/migrate/20150515093735_add_reminder_to_expenses.rb
+++ b/db/migrate/20150515093735_add_reminder_to_expenses.rb
@@ -1,0 +1,6 @@
+class AddReminderToExpenses < ActiveRecord::Migration
+  def change
+    add_reference :expenses, :reminder, index: true
+    add_foreign_key :expenses, :reminders
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150507140025) do
+ActiveRecord::Schema.define(version: 20150515093735) do
 
   create_table "expenses", force: :cascade do |t|
     t.string   "name"
@@ -21,9 +21,11 @@ ActiveRecord::Schema.define(version: 20150507140025) do
     t.integer  "periodic_expense_id"
     t.float    "amount"
     t.date     "paid_on"
+    t.integer  "reminder_id"
   end
 
   add_index "expenses", ["periodic_expense_id"], name: "index_expenses_on_periodic_expense_id"
+  add_index "expenses", ["reminder_id"], name: "index_expenses_on_reminder_id"
 
   create_table "periodic_expenses", force: :cascade do |t|
     t.string   "name"
@@ -41,6 +43,16 @@ ActiveRecord::Schema.define(version: 20150507140025) do
     t.string  "picture",    null: false
     t.integer "expense_id", null: false
   end
+
+  create_table "reminders", force: :cascade do |t|
+    t.string  "message"
+    t.integer "user_id"
+    t.date    "due_on"
+    t.integer "periodic_expense_id"
+  end
+
+  add_index "reminders", ["periodic_expense_id"], name: "index_reminders_on_periodic_expense_id"
+  add_index "reminders", ["user_id"], name: "index_reminders_on_user_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "name"

--- a/spec/models/periodic_expense_runner_spec.rb
+++ b/spec/models/periodic_expense_runner_spec.rb
@@ -6,19 +6,19 @@ describe PeriodicExpenseRunner, type: :model do
   context '#run_for_periodic_expense' do
     context 'with a periodic expense' do
       context 'that is ready to pay' do
-        it 'creates an expense' do
+        it 'creates a reminder' do
           periodic_expense = create(:periodic_expense, start_date: Date.today.last_month, last_paid_on: Date.today)
           allow(periodic_expense).to receive(:due?).and_return(true)
 
-          expect { runner.run_for_periodic_expense(periodic_expense) }.to change { Expense.count }.by(1)
+          expect { runner.run_for_periodic_expense(periodic_expense) }.to change { Reminder.count }.by(1)
         end
       end
 
       context 'that is not ready to pay' do
-        it 'does not create an expense' do
+        it 'does not create a reminder' do
           periodic_expense = instance_double('PeriodicExpense', due?: false)
 
-          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Expense.count }
+          expect { runner.run_for_periodic_expense(periodic_expense) }.not_to change { Reminder.count }
         end
       end
     end
@@ -36,10 +36,10 @@ describe PeriodicExpenseRunner, type: :model do
     end
 
     context 'with no periodic expenses' do
-      it 'does not create expenses' do
+      it 'does not create reminders' do
         runner.run
 
-        expect(Expense.count).to eq 0
+        expect(Reminder.count).to eq 0
       end
     end
   end


### PR DESCRIPTION
PeriodicExpenses now create Reminders instead of Expenses, since Expenses should only be created by Users.
A Reminder has a message and a due date, belongs to the PeriodicExpense
that created it and to the User that is going to pay the Expense. This will serve to remind the User that there is an Expense that is due.
